### PR TITLE
tvOS support proposal

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "SwURL",
     platforms: [
        .iOS(.v13),
+       .tvOS(.v13)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/SwURL/RemoteImage/ImageLoader.swift
+++ b/Sources/SwURL/RemoteImage/ImageLoader.swift
@@ -70,7 +70,13 @@ private extension ImageLoader {
             }
             
             do {
+                #if os(iOS)
                 let directory = try self.fileManager.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true).appendingPathComponent(location.lastPathComponent)
+                #elseif os(tvOS)
+                //there is no user directory on tvOS. 
+                let directory = try self.fileManager.url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true).appendingPathComponent(location.lastPathComponent)
+                #endif
+                
                 try self.fileManager.copyItem(at: location, to: directory)
                 
                 guard


### PR DESCRIPTION
Hi. I tried your library for a tvOS + SwiftUI project i was working on. 
It works (did not install it through the SPM, as tvOS is not a supported platform), but the `ImageLoader` causes a crash, because it wants to use the `userDirectory` which does not exist on tvOS. So I changed it to the caches directory. 
What i propose is to use the `userDirectory` if you are on iOS, and the `cachesDirectory` when you are on tvOS.

- added tvOS as a suported platform
- changed what folder to use in case of tvOS for the ImageLoader, since there is no user directory on tvOS.