### PR TITLE
Add macos support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let package = Package(
     name: "SwURL",
     platforms: [
        .iOS(.v13),
-	   .tvOS(.v13)
+	   .tvOS(.v13),
+        .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
This little change allows me to build SwURL for a macOS framework target. No other changes are required. Thank you for this wonderful little library!