### PR TITLE
copy task within run loop of delegate method

### DIFF
--- a/Sources/SwURL/RemoteImage/Model/Downloader.swift
+++ b/Sources/SwURL/RemoteImage/Model/Downloader.swift
@@ -59,7 +59,7 @@ extension Downloader: URLSessionDownloadDelegate {
 		downloadTask: URLSessionDownloadTask,
 		didFinishDownloadingTo location: URL
 	) {
-        queue.async { [weak self] in
+        queue.sync { [weak self] in
             guard
                 let self = self,
                 var downloadInfo = self.tasks[downloadTask]?.value


### PR DESCRIPTION
The delegate method `urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL)` requires that the file be copied before the end of the method is reached. The file at the given location URL is deleted immediately after. Therefore an `async` execution of the task change does not copy the file in time leading to empty files.